### PR TITLE
BUG-1598 ignore tehtävänimike

### DIFF
--- a/src/main/scala/fi/vm/sade/vst/model/JsonSupport.scala
+++ b/src/main/scala/fi/vm/sade/vst/model/JsonSupport.scala
@@ -175,7 +175,6 @@ trait JsonSupport {
 
   val kayttooikeusryhmaReads: Reads[Kayttooikeusryhma] = (
     (JsPath \ "id").read[Long] and
-      (JsPath \ "name").read[String] and
       (JsPath \ "description" \ "texts").read[List[KayttoikeusDescription]].map(desc => desc.groupBy(_.lang).transform((l, d) => d.head.text)) and
       Reads.pure(Seq.empty) and
       Reads.pure(Seq.empty)
@@ -183,7 +182,6 @@ trait JsonSupport {
 
   val userKayttooikeusryhmaReads: Reads[Kayttooikeusryhma] = (
     (JsPath \ "ryhmaId").read[Long] and
-      (JsPath \ "tehtavanimike").read[String] and
       (JsPath \ "ryhmaNames" \ "texts").read[List[KayttoikeusDescription]].map(desc => desc.groupBy(_.lang).transform((l, d) => d.head.text)) and
       Reads.pure(Seq.empty) and
       Reads.pure(Seq.empty)

--- a/src/main/scala/fi/vm/sade/vst/model/Models.scala
+++ b/src/main/scala/fi/vm/sade/vst/model/Models.scala
@@ -109,7 +109,11 @@ case class TimelineItemUpdate(id: Long, releaseId: Long, date: LocalDate, conten
 @ApiModel
 case class EmailEvent(id: Long, createdAt: LocalDate, releaseId: Long, eventType: String)
 
-case class Kayttooikeusryhma(id: Long, name: String, description: Map[String, Option[String]], roles: Seq[String], categories: Seq[Long])
+case class Kayttooikeusryhma(id: Long,
+                             description: Map[String, Option[String]],
+                             roles: Seq[String],
+                             categories: Seq[Long]
+                            )
 
 case class Kayttooikeus(palveluName: String, role: String)
 

--- a/ui/app/components/editor/targeting/Targeting.jsx
+++ b/ui/app/components/editor/targeting/Targeting.jsx
@@ -93,7 +93,7 @@ function Targeting (props) {
       : userGroups
   }
 
-  const getUserGroupName = (id, groups) => {
+  const getUserGroupDescription = (id, groups) => {
     return R.find(R.propEq('id', id))(groups).description[user.lang.toUpperCase()]
   }
 
@@ -210,7 +210,7 @@ function Targeting (props) {
                 <UserGroupButton
                   key={`releaseUserGroup${group}`}
                   id={group}
-                  text={getUserGroupName(group, userGroupsWithAllItem)}
+                  text={getUserGroupDescription(group, userGroupsWithAllItem)}
                   onClick={controller.toggleUserGroup}
                 />
               )


### PR DESCRIPTION
Tehtävänimike oli joillain käyttäjillä null, joka aiheutti käyttäjäoikeuksien JSONin parsimisen hiljaisen epäonnistumisen. Tällöin käyttäjän ryhmät jäi tyhjäksi, eikä hänelle näytetty minkään ryhmien julkaisuja.

Koska tehtävänimikettä ei käytetä työpöydässä, poistetaan kenttä.