### PR TITLE
no 'no-cors' mode for userDetails request

### DIFF
--- a/ui/app/state/user.js
+++ b/ui/app/state/user.js
@@ -16,9 +16,6 @@ function fetch () {
 
   http({
     url: urls.details,
-    requestOptions: {
-      mode: 'no-cors'
-    },
     onSuccess: user => fetchBus.push(user),
     onError: error => fetchFailedBus.push(error)
   })


### PR DESCRIPTION
This mode removes some headers, including Caller-Id